### PR TITLE
Fix transfer list bottom element bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Sempo",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/src/components/ReceivePaymentFlow/PaymentsUseScreen.js
+++ b/src/components/ReceivePaymentFlow/PaymentsUseScreen.js
@@ -109,7 +109,7 @@ class PaymentsUseScreen extends React.Component {
                                  onPress={() => {
                                      this._selectPaymentUse(0)
                                  }}>
-                        <Text style={{paddingLeft: 10, width: '100%'}}>Other</Text>
+                        <Text style={{paddingLeft: 10, paddingBottom: 10, width: '100%'}}>Other</Text>
                     </Icon.Button>
                 </View>
             )
@@ -126,11 +126,13 @@ class PaymentsUseScreen extends React.Component {
                         { uses }
                     </ScrollView>
                 </View>
-                <BottomAsyncButton
-                    buttonText={strings('SendPaymentCameraScreen.Next').toUpperCase()}
-                    isLoading={false}
-                    onPress={() => this._handleNext()}
-                />
+                <View style={Styles.inputButton}>
+                    <BottomAsyncButton
+                        buttonText={strings('SendPaymentCameraScreen.Next').toUpperCase()}
+                        isLoading={false}
+                        onPress={() => this._handleNext()}
+                    />
+                </View>
             </View>
         )
     }


### PR DESCRIPTION
**Describe the Pull Request**

Adds some padding to the bottom of the transfer list so the last element appears in long lists  

**Todo**

- [x] Link relevant [trello card](https://trello.com/b/PA2LhlOh/sempo-dev) or [related issue](https://github.com/teamsempo/SempoMobileApp/issues) to the pull request
- [x] Request review from relevant @person or team
- [x] QA your pull request. This includes running the app, login, testing changes, [accessibility](https://reactnative.dev/docs/accessibility) etc.
- [x] Bump [package](https://github.com/teamsempo/SempoMobileApp/blob/master/package.json#L3) and [android](https://github.com/teamsempo/SempoMobileApp/blame/master/android/app/build.gradle#L141-L142) versions following Semver
- [ ] Add release notes to [unreleased changelog](https://github.com/teamsempo/SempoMobileApp/blob/master/CHANGELOG.md#unreleased)