### PR TITLE
Make nfc error text more granular

### DIFF
--- a/locales/ar.json
+++ b/locales/ar.json
@@ -97,6 +97,7 @@
   "NFCScreen": {
     "ErrorMessage": "لمس بطاقة",
     "NFCError": "خطأ NFC",
+    "NFCCounterError": "خطأ في تطبيق المعاملة على البطاقة",
     "NFCErrorMessage": "لا يحتوي جهازك على قارئ NFC.",
     "NFCCardError": "خطأ في مصادقة البطاقة",
     "NFCCurrencyError": "لا تحتوي البطاقة على عملة {{currency}}",

--- a/locales/bi.json
+++ b/locales/bi.json
@@ -98,6 +98,7 @@
   "NFCScreen": {
     "ErrorMessage": "Tajem Kad Lo Phon",
     "NFCError": "Problem",
+    "NFCCounterError": "Error Applying Transaction To Card",
     "NFCErrorMessage": "Your device does not have an NFC reader.",
     "NFCCardError": "Card Authentication Error",
     "NFCCurrencyError": "Card does not have currency {{currency}}",

--- a/locales/en.json
+++ b/locales/en.json
@@ -97,6 +97,7 @@
   "NFCScreen": {
     "ErrorMessage": "Hold Card To Back",
     "NFCError": "NFC Error",
+    "NFCCounterError": "Error Applying Transaction To Card",
     "NFCErrorMessage": "Your device does not have an NFC reader.",
     "NFCCardError": "Card Authentication Error",
     "NFCCurrencyError": "Card does not have currency {{currency}}",

--- a/locales/es.json
+++ b/locales/es.json
@@ -98,6 +98,7 @@
   "NFCScreen": {
     "ErrorMessage": "Toque la tarjeta",
     "NFCError": "Error de tarjeta",
+    "NFCCounterError": "Error al aplicar la transacción a la tarjeta",
     "NFCErrorMessage": "Su dispositivo no tiene una lectora NFC.",
     "NFCCardError": "Error de autenticación de la tarjeta",
     "NFCCurrencyError": "La tarjeta no tiene moneda {{currency}}",

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -97,6 +97,7 @@
   "NFCScreen": {
     "ErrorMessage": "Carte Tap",
     "NFCError": "Erreur NFC",
+    "NFCCounterError": "Erreur lors de l'application de la transaction à la carte",
     "NFCErrorMessage": "Votre appareil ne possède pas de lecteur NFC.",
     "NFCCardError": "Erreur d'authentification de la carte",
     "NFCCurrencyError": "La carte n'a pas de devise {{currency}}",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Sempo",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "private": true,
   "scripts": {
     "android": "react-native run-android",

--- a/src/sagas/nfcSaga.js
+++ b/src/sagas/nfcSaga.js
@@ -96,7 +96,7 @@ function* robustlyUpdateCounter(desiredValue, getter, incrementer, allowedAttemp
         }
 
         if (!successfulWrite && attempts > allowedAttempts) {
-            throw strings('NFCScreen.NFCError') // "NFC Error"
+            throw strings('NFCScreen.NFCCounterError') // "Error Applying Transaction"
         }
     }
 }


### PR DESCRIPTION
**Describe the Pull Request**

There are two ways you can get "NFC Error" in the mobile app, and both mean pretty different things. This makes the text different so we can tell what's going on!  

**Todo**

- [x] Link relevant [trello card](https://trello.com/b/PA2LhlOh/sempo-dev) or [related issue](https://github.com/teamsempo/SempoMobileApp/issues) to the pull request
- [x] Request review from relevant @person or team
- [x] QA your pull request. This includes running the app, login, testing changes, [accessibility](https://reactnative.dev/docs/accessibility) etc.
- [x] Bump [package](https://github.com/teamsempo/SempoMobileApp/blob/master/package.json#L3) and [android](https://github.com/teamsempo/SempoMobileApp/blame/master/android/app/build.gradle#L141-L142) versions following Semver
- [ ] Add release notes to [unreleased changelog](https://github.com/teamsempo/SempoMobileApp/blob/master/CHANGELOG.md#unreleased)